### PR TITLE
Step4

### DIFF
--- a/src/main/java/com/clean/architecture/repository/customRepositroy/RegistrationRepositoryCustom.java
+++ b/src/main/java/com/clean/architecture/repository/customRepositroy/RegistrationRepositoryCustom.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public interface RegistrationRepositoryCustom  {
     ResponseDto saveRegistration(RegistrationDto registrationDto);
+    ResponseDto checkRegistrationByUserIdAndScheduleNo(RegistrationDto registrationDto);
     List<RegistrationDto> findAllRegistrationByScheduleNo(RegistrationDto registrationDto);
     List<RegistrationDto> findAllRegistrationByUserId(RegistrationDto registrationDto);
 }

--- a/src/test/java/com/clean/architecture/service/serviceImpl/LectureServiceImplTest.java
+++ b/src/test/java/com/clean/architecture/service/serviceImpl/LectureServiceImplTest.java
@@ -1,0 +1,122 @@
+package com.clean.architecture.service.serviceImpl;
+
+import com.clean.architecture.domain.dto.RegistrationDto;
+import com.clean.architecture.domain.dto.RequestDto;
+import com.clean.architecture.domain.dto.ResponseDto;
+import com.clean.architecture.repository.HistoryRepository;
+import com.clean.architecture.repository.RegistrationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LectureServiceImplTest {
+    private LectureServiceImpl lectureServiceImpl;
+    private RegistrationRepository registrationRepository;
+    private HistoryRepository historyRepository;
+
+    @BeforeEach
+    public void setUp() {
+        registrationRepository = mock(RegistrationRepository.class);
+        historyRepository = mock(HistoryRepository.class);
+        lectureServiceImpl = new LectureServiceImpl(registrationRepository, historyRepository);
+    }
+
+    @Test
+    @DisplayName("동시성 특강 신청")
+    @Transactional
+    void applyLecture() throws ExecutionException, InterruptedException {
+        // given
+        int threadCount = 40;
+        int allowStudentCnt = 30;
+        List<CompletableFuture<ResponseDto>> futures = new ArrayList<>();
+
+        RequestDto requestDto = new RequestDto();
+        requestDto.setUserId(1L);
+        requestDto.setScheduleNo(1);
+
+        ResponseDto responseDto = new ResponseDto();
+        responseDto.setSuccess(true);
+        when(lectureServiceImpl.applyLecture(requestDto)).thenReturn(responseDto);
+
+        // when
+        Integer scheduleNo = 1;
+        for (int i = 0; i < threadCount; i++) {
+            Long userId = 1L + i;
+            CompletableFuture<ResponseDto> future = CompletableFuture.supplyAsync(() -> {
+                RequestDto temp = new RequestDto();
+                temp.setUserId(userId);
+                temp.setScheduleNo(scheduleNo);
+                return lectureServiceImpl.applyLecture(temp);
+            });
+            futures.add(future);
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        int successCount = 0;
+        for (CompletableFuture<ResponseDto> future : futures) {
+            ResponseDto response = future.get();
+            if (response.getSuccess()) {
+                successCount++;
+            }
+        }
+
+        // then
+        assertThat(successCount).isEqualTo(allowStudentCnt);
+    }
+
+    @Test
+    @DisplayName("같은 유저 특강 신청")
+    void sameUserApplyLecture() throws ExecutionException, InterruptedException {
+        // given
+        List<CompletableFuture<ResponseDto>> futures = new ArrayList<>();
+        int threadCount = 40;
+        Integer scheduleNo = 1;
+        Long userId = 1L;
+        int resultCnt = 1;
+
+        RequestDto requestDto = new RequestDto();
+        requestDto.setUserId(1L);
+        requestDto.setScheduleNo(1);
+
+        ResponseDto responseDto = new ResponseDto();
+        responseDto.setSuccess(true);
+        when(lectureServiceImpl.applyLecture(requestDto)).thenReturn(responseDto);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            CompletableFuture<ResponseDto> future = CompletableFuture.supplyAsync(() -> {
+                RequestDto paramTest = new RequestDto();
+                paramTest.setUserId(userId);
+                paramTest.setScheduleNo(scheduleNo);
+                return lectureServiceImpl.applyLecture(paramTest);
+            });
+            futures.add(future);
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        int successCount = 0;
+
+        for (CompletableFuture<ResponseDto> future : futures) {
+            ResponseDto response = future.get();
+            if (response.getSuccess()) {
+                successCount++;
+            }
+        }
+
+        // then
+        assertThat(successCount).isEqualTo(resultCnt);
+    }
+}


### PR DESCRIPTION
[ 변경사항 ]
1. 비관적락 적용
2. 서비스 테스트 로직 작성

[ 리뷰포인트 ]
1. when으로 결괏값을 true로 리턴 받고 싶은데 실제 CompletableFuture.supplyAsync 동작 후에는 false만 반환이 되는 원인을 잘 모르겠습니다. [:bulb: true의 값을 들고 있는 객체 응답 세팅](https://github.com/iPhone-design/hhplus-clean-architecture-java/pull/2/commits/439708599194ad4c7d2c8883c8555966d21257f0#diff-1d36203acdcad7bc8e783a9eac4cdb0989af2178b71806ddccee25b1e1e805a3R50) [:wrench: false로만 응답](https://github.com/iPhone-design/hhplus-clean-architecture-java/pull/2/commits/439708599194ad4c7d2c8883c8555966d21257f0#diff-1d36203acdcad7bc8e783a9eac4cdb0989af2178b71806ddccee25b1e1e805a3R70)

3. 멘토링 시간 때 참조키를 모두 제거하라고 하셨는데, 그렇다면 모든 테이블들을 연관 관계없이 모두 단일 테이블로 관리를 해야 한다는 의미가 맞을까요?? 현재는 fk로 서로 테이블을 참조하고 있는 형태입니다. ex) fk를 pk를 사용하여 복합키로 세팅 [:bulb: ERD](https://github.com/iPhone-design/hhplus-clean-architecture-java/blob/master/README.md)
   
